### PR TITLE
Fix App\Filters\OauthFilter

### DIFF
--- a/app/Filters/OauthFilter.php
+++ b/app/Filters/OauthFilter.php
@@ -11,22 +11,22 @@ use \OAuth2\Response;
 
 class OauthFilter implements FilterInterface
 {
-    public function before(RequestInterface $request)
-    {
-       $oauth = new Oauth();
-       $request = Request::createFromGlobals();
-       $response = new Response();
+  public function before(RequestInterface $request, $arguments = null)
+  {
+    $oauth = new Oauth();
+    $request = Request::createFromGlobals();
+    $response = new Response();
 
-       if(!$oauth->server->verifyResourceRequest($request)){
-         $oauth->server->getResponse()->send();
-         die();
-       }
+    if (!$oauth->server->verifyResourceRequest($request)) {
+      $oauth->server->getResponse()->send();
+      die();
     }
+  }
 
-    //--------------------------------------------------------------------
+  //--------------------------------------------------------------------
 
-    public function after(RequestInterface $request, ResponseInterface $response)
-    {
-        // Do something here
-    }
+  public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
+  {
+    // Do something here
+  }
 }


### PR DESCRIPTION
CRITICAL - 2022-04-21 10:36:17 --> Declaration of App\Filters\OauthFilter::before(CodeIgniter\HTTP\RequestInterface $request) must be compatible with CodeIgniter\Filters\FilterInterface::before(CodeIgniter\HTTP\RequestInterface $request, $arguments = null)
#0 [internal function]: CodeIgniter\Debug\Exceptions->shutdownHandler()
#1 {main}
